### PR TITLE
Add check for non-Nil $article.pubDate

### DIFF
--- a/layouts/partials/webring.html
+++ b/layouts/partials/webring.html
@@ -50,7 +50,9 @@
             {{ end }}
           </a>
         </small>
+        {{ if $article.pubDate }}
         <small class="date">{{  time.Format "2 Jan 2006" (time.AsTime $article.pubDate) }}</small>
+        {{ end }}
       </div>
     {{ end }}
   </section>


### PR DESCRIPTION
Hugo compilation often errors out `execute of template failed: template: partials/webring.html:53:62: executing "partials/webring.html" at <time.AsTime>: error calling AsTime: unable to cast <nil> of type <nil> to Time`. A simple non-Nil check surrounding the offending code block fixes the issue, when $article.pubDate is nil.